### PR TITLE
Add support for Accessory Type

### DIFF
--- a/Example/Source/Base.lproj/Main.storyboard
+++ b/Example/Source/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16085" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FJQ-W8-nq8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FJQ-W8-nq8">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16078.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -50,7 +50,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="348" height="60"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single Section" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1vv-ZX-hB5">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Single Section w. Disclosure Indicator" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1vv-ZX-hB5">
                                                     <rect key="frame" x="16" y="0.0" width="332" height="60"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/Example/Source/CustomModel.swift
+++ b/Example/Source/CustomModel.swift
@@ -14,6 +14,7 @@ struct CustomModel: ViewModel {
     var title: String
     var cellType: (Configurable & Reusable).Type = DefaultCell.self
     var separatorInsets: NSDirectionalEdgeInsets = .zero
+    var accessory: UITableViewCell.AccessoryType = .none
     var didTap: IndexPathClosure?
     var didDelete: IndexPathClosure?
 }

--- a/Example/Source/ImageModel.swift
+++ b/Example/Source/ImageModel.swift
@@ -15,6 +15,7 @@ struct ImageModel: ViewModel {
     let id: String = UUID().uuidString
     var cellType: (Configurable & Reusable).Type = ImageCell.self
     var separatorInsets: NSDirectionalEdgeInsets = .zero
+    let accessory: UITableViewCell.AccessoryType = .none
     let didTap: IndexPathClosure? = nil
     let didDelete: IndexPathClosure? = nil
 }

--- a/Example/Source/SingleSectionViewController.swift
+++ b/Example/Source/SingleSectionViewController.swift
@@ -35,17 +35,19 @@ final class SingleSectionViewController: UIViewController {
             self.table.reloadData()
         }
 
+        let accessory: UITableViewCell.AccessoryType = .none
+
         var models = [
-            CustomModel(title: "Einstellungen", didTap: { (sender) in print("Einstellungen") }),
-            CustomModel(title: "Impressung", didTap: { (sender) in print("Impressum") }),
-            CustomModel(title: "Empfehlen", didTap: { (sender) in print("Empfehlen") }),
-            CustomModel(title: "Hilfe", didTap: { (sender) in print("Hilfe") }),
-            CustomModel(title: "Logout", didTap: { (sender) in print("Logout") })
+            CustomModel(title: "Einstellungen", accessory: accessory, didTap: { (sender) in print("Einstellungen") }),
+            CustomModel(title: "Impressung", accessory: accessory, didTap: { (sender) in print("Impressum") }),
+            CustomModel(title: "Empfehlen", accessory: accessory, didTap: { (sender) in print("Empfehlen") }),
+            CustomModel(title: "Hilfe", accessory: accessory, didTap: { (sender) in print("Hilfe") }),
+            CustomModel(title: "Logout", accessory: accessory, didTap: { (sender) in print("Logout") })
         ]
         // Changing the connected cell class for all models. Alternatively you
         // can just create a new model and set another default cell type.
         for index in 0..<models.count {
-            models[index].cellType = DisclosureCell.self
+            models[index].cellType = DefaultCell.self
         }
         dataSource.collection = ModelCollection(models: models)
     }

--- a/Source/Classes/Source.swift
+++ b/Source/Classes/Source.swift
@@ -61,6 +61,7 @@ extension Source: UITableViewDataSource {
         let model = collection[indexPath]
         let cell = tableView.dequeueReusableCell(withIdentifier: model.cellType.reuseIdentifier, for: indexPath)
         cell.selectionStyle = model.didTap == nil ? .none : .default
+        cell.accessoryType = model.accessory
 
         do {
             try (cell as? Configurable)?.configure(with: model)

--- a/Source/Classes/ViewModel.swift
+++ b/Source/Classes/ViewModel.swift
@@ -14,6 +14,7 @@ public protocol ViewModel {
     var id: String { get }
     var cellType: (Configurable & Reusable).Type { get }
     var separatorInsets: NSDirectionalEdgeInsets { get }
+    var accessory: UITableViewCell.AccessoryType { get }
     var didTap: IndexPathClosure? { get }
     var didDelete: IndexPathClosure? { get }
 }


### PR DESCRIPTION
The ViewModel supports now accessoryType. Means you can specify which UITableViewCell.AccessoryType you want to show. Specify `.none` to show no accessory type.
