### PR TITLE
Implement Custom Section Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* [#29](https://github.com/dbdrive/beiwagen/pull/29): Implement Custom Section Headers - [@stherold](https://github.com/stherold).
 
 ## [1.6.0] - 2020-07-23
 * [#28](https://github.com/dbdrive/beiwagen/pull/28): Add ModelCollection.insert() and Section.insert() - [@stherold](https://github.com/stherold).

--- a/Example/Source/DefaultCell.swift
+++ b/Example/Source/DefaultCell.swift
@@ -44,7 +44,7 @@ extension DefaultCell: Configurable {
 
     func configure(with model: ViewModel?) throws {
         guard let myModel = model as? CustomModel else {
-            throw Source.Error.invalidModel(model)
+            throw ModelError.invalidModel(model)
         }
         titleLabel.text = myModel.title
     }

--- a/Example/Source/DisclosureCell.swift
+++ b/Example/Source/DisclosureCell.swift
@@ -44,7 +44,7 @@ extension DisclosureCell: Configurable, Reusable {
 
     func configure(with model: ViewModel?) throws {
         guard let myModel = model as? CustomModel else {
-            throw Source.Error.invalidModel(model)
+            throw ModelError.invalidModel(model)
         }
         titleLabel.text = myModel.title
         accessoryType = .disclosureIndicator

--- a/Example/Source/ImageCell.swift
+++ b/Example/Source/ImageCell.swift
@@ -73,7 +73,7 @@ extension ImageCell: HeightConfigurable, Reusable {
     func configure(with model: ViewModel?) throws {
 
         guard let myModel = model as? ImageModel else {
-            throw Source.Error.invalidModel(model)
+            throw ModelError.invalidModel(model)
         }
         imgView.image = myModel.image
     }

--- a/Example/Source/ImageListViewController.swift
+++ b/Example/Source/ImageListViewController.swift
@@ -38,14 +38,14 @@ final class ImageListViewController: UIViewController {
 
         dataSource.dataSourceDidChangedClosure = { [weak self] (source) in
             guard let self = self else { return }
-            source.registerCells(for: self.table)
+            source.registerCellsAndSupplementaryViews(for: self.table)
             self.table.reloadData()
         }
 
         let models = images.map { ImageModel(image: $0) }
 
         let sections = [
-            DefaultSection(models: models, headerTitle: nil, footerTitle: nil)
+            DefaultSection(models: models)
         ]
         dataSource.collection = ModelCollection(sections: sections)
 

--- a/Example/Source/MultiSectionViewController.swift
+++ b/Example/Source/MultiSectionViewController.swift
@@ -32,7 +32,7 @@ final class MultiSectionViewController: UIViewController {
 
         dataSource.dataSourceDidChangedClosure = { [weak self] (source) in
             guard let self = self else { return }
-            source.registerCells(for: self.table)
+            source.registerCellsAndSupplementaryViews(for: self.table)
             self.table.reloadData()
         }
 
@@ -49,8 +49,7 @@ final class MultiSectionViewController: UIViewController {
                                CustomModel(title: "Mom"),
                                CustomModel(title: "Dad"),
                                CustomModel(title: "Brother")],
-                      headerTitle: "Family",
-                      footerTitle: nil),
+                        headerModel: DefaultSupplementaryViewModel(title: "Family")),
 
             DefaultSection(models: [CustomModel(title: "Apple"),
                                CustomModel(title: "Banana"),
@@ -64,10 +63,9 @@ final class MultiSectionViewController: UIViewController {
                                CustomModel(title: "Apple"),
                                CustomModel(title: "Banana"),
                                CustomModel(title: "Grape")],
-                      headerTitle: "Fruits",
-                      footerTitle: nil),
+                      headerModel: DefaultSupplementaryViewModel(title: "Fruits")),
 
-            // No header title -> no section index title
+            // No header model -> no section header (estimatedHeightForHeaderInSection has to return 0 for this)
             DefaultSection(models: [CustomModel(title: "Apple"),
                                CustomModel(title: "Banana"),
                                CustomModel(title: "Grape"),
@@ -79,9 +77,7 @@ final class MultiSectionViewController: UIViewController {
                                CustomModel(title: "Grape"),
                                CustomModel(title: "Apple"),
                                CustomModel(title: "Banana"),
-                               CustomModel(title: "Grape")],
-                      headerTitle: nil,
-                      footerTitle: nil),
+                               CustomModel(title: "Grape")]),
 
             DefaultSection(models: [CustomModel(title: "Vampire"),
                                CustomModel(title: "Lycan"),
@@ -103,8 +99,7 @@ final class MultiSectionViewController: UIViewController {
                                CustomModel(title: "Clown"),
                                CustomModel(title: "God"),
                                CustomModel(title: "Djin")],
-                      headerTitle: "Monsters",
-                      footerTitle: nil)
+                      headerModel: DefaultSupplementaryViewModel(title: "Monsters"))
         ]
         dataSource.collection = ModelCollection(sections: sections)
     }
@@ -134,5 +129,28 @@ extension MultiSectionViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         dataSource.cellHeightCache[indexPath] ?? UITableView.automaticDimension
+    }
+
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+
+        let model = dataSource.collection[section]
+
+        guard let id = model.headerModel?.viewType.reuseIdentifier else {
+            return nil
+        }
+
+        guard let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: id) as? ConfigurableSupplementaryView else {
+            return nil
+        }
+
+        do {
+            try view.configure(with: model.headerModel)
+        } catch {}
+
+        return view
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        dataSource.collection[section].headerModel == nil ? 0 : 50
     }
 }

--- a/Example/Source/SimpleExampleViewController.swift
+++ b/Example/Source/SimpleExampleViewController.swift
@@ -31,7 +31,7 @@ final class SimpleExampleViewController: UIViewController {
 
         dataSource.dataSourceDidChangedClosure = { [weak self] (source) in
             guard let self = self else { return }
-            source.registerCells(for: self.table)
+            source.registerCellsAndSupplementaryViews(for: self.table)
             self.table.reloadData()
         }
 

--- a/Example/Source/SingleSectionViewController.swift
+++ b/Example/Source/SingleSectionViewController.swift
@@ -46,7 +46,7 @@ final class SingleSectionViewController: UIViewController {
 
         dataSource.dataSourceDidChangedClosure = { [weak self] (source) in
             guard let self = self else { return }
-            source.registerCells(for: self.table)
+            source.registerCellsAndSupplementaryViews(for: self.table)
             self.table.reloadData()
         }
 

--- a/Source.xcodeproj/project.pbxproj
+++ b/Source.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		B980730322FA4C0F004B2674 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98072FA22FA4C0F004B2674 /* Section.swift */; };
 		B980730422FA4C0F004B2674 /* UITableViewCell+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B98072FB22FA4C0F004B2674 /* UITableViewCell+Extensions.swift */; };
 		B990084823FF268B00DCABE4 /* HeightConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B990084723FF268B00DCABE4 /* HeightConfigurable.swift */; };
+		B992F41B24E175D000C61FA5 /* ConfigurableSupplementaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B992F41A24E175D000C61FA5 /* ConfigurableSupplementaryView.swift */; };
+		B9B9744E24E18ED900E94A44 /* SupplementaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B9744D24E18ED900E94A44 /* SupplementaryViewModel.swift */; };
 		B9F73F4A23F6EEE9007F4ECA /* SourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F73F4923F6EEE9007F4ECA /* SourceTests.swift */; };
 		B9F73F4C23F6EEE9007F4ECA /* Source.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B98072DE22FA4B86004B2674 /* Source.framework */; };
 /* End PBXBuildFile section */
@@ -49,6 +51,8 @@
 		B98072FA22FA4C0F004B2674 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		B98072FB22FA4C0F004B2674 /* UITableViewCell+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extensions.swift"; sourceTree = "<group>"; };
 		B990084723FF268B00DCABE4 /* HeightConfigurable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeightConfigurable.swift; sourceTree = "<group>"; };
+		B992F41A24E175D000C61FA5 /* ConfigurableSupplementaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableSupplementaryView.swift; sourceTree = "<group>"; };
+		B9B9744D24E18ED900E94A44 /* SupplementaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupplementaryViewModel.swift; sourceTree = "<group>"; };
 		B9F73F4723F6EEE9007F4ECA /* SourceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SourceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9F73F4923F6EEE9007F4ECA /* SourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceTests.swift; sourceTree = "<group>"; };
 		B9F73F4B23F6EEE9007F4ECA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -128,12 +132,14 @@
 			isa = PBXGroup;
 			children = (
 				B98072F622FA4C0F004B2674 /* Configurable.swift */,
+				B992F41A24E175D000C61FA5 /* ConfigurableSupplementaryView.swift */,
 				B990084723FF268B00DCABE4 /* HeightConfigurable.swift */,
 				B98072F422FA4C0F004B2674 /* ModelCollection.swift */,
 				B98072F922FA4C0F004B2674 /* NSDirectionalLayoutEdges+Extensions.swift */,
 				B98072F722FA4C0F004B2674 /* Reusable.swift */,
 				B98072FA22FA4C0F004B2674 /* Section.swift */,
 				B98072F322FA4C0F004B2674 /* Source.swift */,
+				B9B9744D24E18ED900E94A44 /* SupplementaryViewModel.swift */,
 				B98072FB22FA4C0F004B2674 /* UITableViewCell+Extensions.swift */,
 				B98072F822FA4C0F004B2674 /* ViewModel.swift */,
 			);
@@ -291,7 +297,9 @@
 				B980730022FA4C0F004B2674 /* Reusable.swift in Sources */,
 				B980730222FA4C0F004B2674 /* NSDirectionalLayoutEdges+Extensions.swift in Sources */,
 				B980730322FA4C0F004B2674 /* Section.swift in Sources */,
+				B9B9744E24E18ED900E94A44 /* SupplementaryViewModel.swift in Sources */,
 				B98072FF22FA4C0F004B2674 /* Configurable.swift in Sources */,
+				B992F41B24E175D000C61FA5 /* ConfigurableSupplementaryView.swift in Sources */,
 				B98072FC22FA4C0F004B2674 /* Source.swift in Sources */,
 				B980730422FA4C0F004B2674 /* UITableViewCell+Extensions.swift in Sources */,
 				B98072FD22FA4C0F004B2674 /* ModelCollection.swift in Sources */,

--- a/Source/Classes/Configurable.swift
+++ b/Source/Classes/Configurable.swift
@@ -13,8 +13,7 @@ public protocol Configurable: class {
     /// Configures your cell using a view model.
     /// - parameters:
     ///   - model: The view model that configures the cell.
-    /// - note: This protocol must be a class-based protocol because
-    /// `tableView.register` requires `AnyClass`.
+    /// - note: This protocol must be a class-based protocol because `tableView.register` requires `AnyClass`.
     /// - throws: Throw an error when you receive an unexpected `ViewModel`
     func configure(with model: ViewModel?) throws
 }

--- a/Source/Classes/ConfigurableSupplementaryView.swift
+++ b/Source/Classes/ConfigurableSupplementaryView.swift
@@ -1,0 +1,19 @@
+//
+//  ConfigurableHeaderFooter.swift
+//  Source
+//
+//  Created by Stefan Herold on 10.08.20.
+//  Copyright © 2020 Stefan Herold. All rights reserved.
+//
+
+import UIKit
+
+public protocol ConfigurableSupplementaryView: UIView {
+
+    /// Configures your section header/footer using a view model.
+    /// - parameters:
+    ///   - model: The view model that configures the supplementary view.
+    /// - note: This protocol must be a class-based protocol because `tableView.register` requires `AnyClass`.
+    /// - throws: Throw an error when you receive an unexpected `SupplementaryViewModel`
+    func configure(with model: SupplementaryViewModel?) throws
+}

--- a/Source/Classes/ModelCollection.swift
+++ b/Source/Classes/ModelCollection.swift
@@ -10,11 +10,11 @@ import UIKit
 
 public struct ModelCollection {
 
-    private var sections: [Section]
+    private(set) var sections: [Section]
 
     var sectionsWithIndexTitles: [(section: Int, indexTitle: String)] {
         sections.enumerated().compactMap {
-            guard let title = $0.element.headerTitle else { return nil }
+            guard let title = $0.element.headerModel?.title, !title.isEmpty else { return nil }
             return ($0.offset, title)
         }
     }

--- a/Source/Classes/Section.swift
+++ b/Source/Classes/Section.swift
@@ -10,8 +10,9 @@ import Foundation
 
 public protocol Section {
     var models: [ViewModel] { get set }
-    var headerTitle: String? { get }
-    var footerTitle: String? { get }
+    var sectionIndexTitle: String? { get set }
+    var headerModel: SupplementaryViewModel? { get set }
+    var footerModel: SupplementaryViewModel? { get set }
 }
 
 public extension Section {
@@ -32,12 +33,19 @@ public extension Section {
 
 public struct DefaultSection: Section {
     public var models: [ViewModel]
-    public let headerTitle: String?
-    public let footerTitle: String?
+    public var sectionIndexTitle: String?
+    public var headerModel: SupplementaryViewModel?
+    public var footerModel: SupplementaryViewModel?
 
-    public init(models: [ViewModel], headerTitle: String? = nil, footerTitle: String? = nil) {
+    public init(models: [ViewModel],
+                sectionIndexTitle: String? = nil,
+                headerModel: SupplementaryViewModel? = nil,
+                footerModel: SupplementaryViewModel? = nil) {
+
         self.models = models
-        self.headerTitle = headerTitle
-        self.footerTitle = footerTitle
+        self.sectionIndexTitle = sectionIndexTitle
+
+        if let headerModel = headerModel { self.headerModel = headerModel }
+        if let footerModel = footerModel { self.footerModel = footerModel }
     }
 }

--- a/Source/Classes/Source.swift
+++ b/Source/Classes/Source.swift
@@ -10,11 +10,11 @@ import UIKit
 
 public typealias DataSourceDidChangedClosure = (_ dataSource: Source) -> Void
 
-public final class Source: NSObject {
+public enum ModelError<T>: Swift.Error {
+    case invalidModel(T?)
+}
 
-    public enum Error: Swift.Error {
-        case invalidModel(ViewModel?)
-    }
+public final class Source: NSObject {
 
     public var collection: ModelCollection = ModelCollection() {
         didSet {
@@ -39,9 +39,14 @@ public final class Source: NSObject {
         self.numberOfLastSeparatorsToHide = numberOfLastSeparatorsToHide
     }
 
-    public func registerCells(for table: UITableView) {
+    public func registerCellsAndSupplementaryViews(for table: UITableView) {
+
         collection.allModels.forEach {
             table.register($0.cellType, forCellReuseIdentifier: $0.cellType.reuseIdentifier)
+        }
+
+        collection.sections.compactMap(\.headerModel).forEach { (model) in
+            table.register(model.viewType, forHeaderFooterViewReuseIdentifier: model.viewType.reuseIdentifier)
         }
     }
 }
@@ -96,14 +101,6 @@ extension Source: UITableViewDataSource {
     }
 
     // MARK: - Section Index Titles
-
-    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        collection[section].headerTitle
-    }
-
-    public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        collection[section].footerTitle
-    }
 
     public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         useSectionIndexTitles ? collection.sectionsWithIndexTitles.compactMap { $0.indexTitle } : nil

--- a/Source/Classes/SupplementaryViewModel.swift
+++ b/Source/Classes/SupplementaryViewModel.swift
@@ -1,0 +1,85 @@
+//
+//  SupplementaryViewModel.swift
+//  Source
+//
+//  Created by Stefan Herold on 10.08.20.
+//  Copyright © 2020 Stefan Herold. All rights reserved.
+//
+
+import UIKit
+
+public protocol SupplementaryViewModel {
+
+    var title: String { get }
+    var viewType: (ConfigurableSupplementaryView & Reusable).Type { get }
+}
+
+public struct DefaultSupplementaryViewModel: SupplementaryViewModel {
+
+    public var title: String
+    public var insets: NSDirectionalEdgeInsets
+    public var bgColor: UIColor?
+    public var textAttributes: [NSAttributedString.Key: Any]?
+
+    public let viewType: (ConfigurableSupplementaryView & Reusable).Type = DefaultSupplementaryView.self
+
+    public init(title: String,
+                insets: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0),
+                bgColor: UIColor? = nil,
+                textAttributes: [NSAttributedString.Key: Any]? = nil) {
+
+        self.title = title
+        self.insets = insets
+        self.textAttributes = textAttributes
+
+        if #available(iOS 13.0, *) {
+            self.bgColor = bgColor ?? UIColor.systemGray5
+        } else {
+            self.bgColor = bgColor ?? UIColor.lightGray
+        }
+    }
+}
+
+class DefaultSupplementaryView: UITableViewHeaderFooterView, ConfigurableSupplementaryView, Reusable {
+
+    private let titleLabel = UILabel()
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    func setup() {
+        let backgroundView = UIView()
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        self.backgroundView = backgroundView
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.adjustsFontForContentSizeCategory = true
+        contentView.addSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+        ])
+    }
+
+    public func configure(with model: SupplementaryViewModel?) throws {
+
+        guard let viewModel = model as? DefaultSupplementaryViewModel else {
+            throw ModelError.invalidModel(model)
+        }
+
+        contentView.directionalLayoutMargins = viewModel.insets
+
+        backgroundView?.backgroundColor = viewModel.bgColor
+        titleLabel.attributedText = NSAttributedString(string: viewModel.title, attributes: viewModel.textAttributes)
+    }
+}

--- a/Source/Classes/ViewModel.swift
+++ b/Source/Classes/ViewModel.swift
@@ -22,3 +22,7 @@ public protocol ViewModel {
 public func == (lhs: ViewModel, rhs: ViewModel) -> Bool {
     lhs.id == rhs.id
 }
+
+public enum ViewModelError: Swift.Error {
+    case invalidModel(ViewModel?)
+}


### PR DESCRIPTION
We now have headerModel and footerModel that are nil by default but can
be configured similar like cells using a custom model and view
implementation.
The only difference is that showing them is controlled via the
UITableViewDelegate so you have to implement this functionality inside
your app. But due to the new protocol SupplementaryViewModel and
ConfigurableSupplementaryView this is very easy. For an example you can
have a look at MultiSectionViewController from the example in Source.
