### PR TITLE
Fix Cells Separator Inset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Changelog
 
 ## [Unreleased]
+* [#31](https://github.com/dbdrive/beiwagen/pull/31): Fix Cells Separator Inset - [@Blackjacx](https://github.com/blackjacx).
 
 ## [1.7.0] - 2020-08-11
-* [#29](https://github.com/dbdrive/beiwagen/pull/29): Implement Custom Section Headers - [@stherold](https://github.com/stherold).
+* [#29](https://github.com/dbdrive/beiwagen/pull/29): Implement Custom Section Headers - [@Blackjacx](https://github.com/blackjacx).
 
 ## [1.6.0] - 2020-07-23
-* [#28](https://github.com/dbdrive/beiwagen/pull/28): Add ModelCollection.insert() and Section.insert() - [@stherold](https://github.com/stherold).
+* [#28](https://github.com/dbdrive/beiwagen/pull/28): Add ModelCollection.insert() and Section.insert() - [@Blackjacx](https://github.com/blackjacx).
 
 ## [1.5.0] - 2020-06-25
-* [#27](https://github.com/dbdrive/beiwagen/pull/27): Add support for Accessory Type - [@stherold](https://github.com/stherold).
+* [#27](https://github.com/dbdrive/beiwagen/pull/27): Add support for Accessory Type - [@Blackjacx](https://github.com/blackjacx).
 
 ## [1.4.0] - 2020-04-16
 * [#26](https://github.com/Blackjacx/Source/pull/26): Enable module stability - [@Blackjacx](https://github.com/blackjacx).

--- a/Source/Classes/UITableViewCell+Extensions.swift
+++ b/Source/Classes/UITableViewCell+Extensions.swift
@@ -10,7 +10,6 @@ import UIKit
 
 public extension UITableViewCell {
 
-    // Adjusting the separator insets: http://stackoverflow.com/a/39005773/971329
     func adjustCellSeparatorInsets(at indexPath: IndexPath,
                                    for modelCollection: ModelCollection,
                                    numberOfLastSeparatorsToHide: Int) {
@@ -33,8 +32,5 @@ public extension UITableViewCell {
 
         // prevent the cell from inheriting the tableView's margin settings
         preservesSuperviewLayoutMargins = false
-
-        // explicitly setting cell's layout margins
-        directionalLayoutMargins = insets
     }
 }


### PR DESCRIPTION
From an old article I leaned to set the directionalLayoutMatrgins
for hiding the separator insets which is not correct anymore since
it pushes the complete cell content into a direction. Now by
removing this from the adjustment function the
directionalLayoutMargins can actually be used to control the cells
insets which is as intened.

## Issue
- Resolve #30 - 🚨 Fix Cells LayoutMargins